### PR TITLE
IsOpen method now checks mongo cluster state.

### DIFF
--- a/src/Persistence/MongoDbPersistence.cs
+++ b/src/Persistence/MongoDbPersistence.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using MongoDB.Driver;
+using MongoDB.Driver.Core.Clusters;
 using MongoDB.Driver.Core.Servers;
 using PipServices3.Commons.Config;
 using PipServices3.Commons.Errors;
@@ -185,20 +186,26 @@ namespace PipServices3.MongoDb.Persistence
             // For mongo to register an open connection, an operation has to be applied to the client
             _connection.ListDatabases();
 
-            // Check that each server in the cluster is connected
-            foreach (var server in _connection.Cluster.Description.Servers)
-            {
-                if (server.State == ServerState.Disconnected)
-                {
-                    _logger.Trace(null, "Server with ServerId {0} is disconnected", new[] { server.ServerId });
-                    return false;
-                }
-            }
+            // DEV NOTE
+            // We can check for connectivity to the entire cluster, however this may be overkill
+            // and may generate false positives if one server in the cluster has an issue.
+            // Mongo clusters require at least 3 nodes to function correctly.
+            // For now we will just check the state of the cluster.
 
-            return true;
+            //// Check that each server in the cluster is connected
+            //foreach (var server in _connection.Cluster.Description.Servers)
+            //{
+            //    if (server.State == ServerState.Disconnected)
+            //    {
+            //        _logger.Trace(null, "Server with ServerId {0} is disconnected", new[] { server.ServerId });
+            //        return false;
+            //    }
+            //}
+
+            //return true;
 
             // Check that the cluster is connected
-            //return _connection.Cluster.Description.State == ClusterState.Connected;
+            return _connection.Cluster.Description.State == ClusterState.Connected;
         }
 
         /// <summary>

--- a/test/Persistence/MongoDbPersistenceTest.cs
+++ b/test/Persistence/MongoDbPersistenceTest.cs
@@ -1,0 +1,60 @@
+﻿using PipServices3.Commons.Config;
+using System;
+using Xunit;
+
+namespace PipServices3.MongoDb.Persistence
+{
+    public class MongoDbPersistenceTest
+    {
+        private static MongoDbDummyPersistence Db { get; } = new MongoDbDummyPersistence();
+
+        private string mongoUri;
+        private string mongoHost;
+        private string mongoPort;
+        private string mongoDatabase;
+
+        public MongoDbPersistenceTest()
+        {
+            mongoUri = Environment.GetEnvironmentVariable("MONGO_URI");
+            mongoHost = Environment.GetEnvironmentVariable("MONGO_HOST") ?? "localhost";
+            mongoPort = Environment.GetEnvironmentVariable("MONGO_PORT") ?? "27017";
+            mongoDatabase = Environment.GetEnvironmentVariable("MONGO_DB") ?? "test";
+
+            if (mongoUri == null && mongoHost == null)
+                return;
+
+            if (Db == null) return;
+        }
+
+        [Fact]
+        public void TestOpenAsync_Success()
+        {
+            Db.Configure(ConfigParams.FromTuples(
+                "connection.uri", mongoUri,
+                "connection.host", mongoHost,
+                "connection.port", mongoPort,
+                "connection.database", mongoDatabase
+            ));
+
+            Db.OpenAsync(null).Wait();
+
+            var actual = Db.IsOpen();
+
+            Assert.True(actual);
+        }
+
+        [Fact]
+        public void TestOpenAsync_Failure()
+        {
+            Db.Configure(ConfigParams.FromTuples(
+                "connection.uri", mongoUri,
+                "connection.host", mongoHost,
+                "connection.port", "1234",
+                "connection.database", mongoDatabase
+            ));
+
+            var ex = Assert.Throws<AggregateException>(() => Db.OpenAsync(null).Wait());
+            Assert.Equal("Connection to mongodb failed", ex.InnerException.Message);
+        }
+    }
+}

--- a/test/Persistence/MongoDbPersistenceTest.cs
+++ b/test/Persistence/MongoDbPersistenceTest.cs
@@ -7,6 +7,7 @@ namespace PipServices3.MongoDb.Persistence
     /// <summary>
     /// Unit tests for the <c>MongoDbPersistenceTest</c> class
     /// </summary>
+    [Collection("Sequential")]
     public class MongoDbPersistenceTest
     {
         private MongoDbDummyPersistence Db { get; }

--- a/test/Persistence/MongoDbPersistenceTest.cs
+++ b/test/Persistence/MongoDbPersistenceTest.cs
@@ -4,9 +4,12 @@ using Xunit;
 
 namespace PipServices3.MongoDb.Persistence
 {
+    /// <summary>
+    /// Unit tests for the <c>MongoDbPersistenceTest</c> class
+    /// </summary>
     public class MongoDbPersistenceTest
     {
-        private static MongoDbDummyPersistence Db { get; } = new MongoDbDummyPersistence();
+        private MongoDbDummyPersistence Db { get; }
 
         private string mongoUri;
         private string mongoHost;
@@ -15,6 +18,8 @@ namespace PipServices3.MongoDb.Persistence
 
         public MongoDbPersistenceTest()
         {
+            Db = new MongoDbDummyPersistence();
+
             mongoUri = Environment.GetEnvironmentVariable("MONGO_URI");
             mongoHost = Environment.GetEnvironmentVariable("MONGO_HOST") ?? "localhost";
             mongoPort = Environment.GetEnvironmentVariable("MONGO_PORT") ?? "27017";
@@ -46,6 +51,8 @@ namespace PipServices3.MongoDb.Persistence
         [Fact]
         public void TestOpenAsync_Failure()
         {
+            Db.CloseAsync(null).Wait();
+
             Db.Configure(ConfigParams.FromTuples(
                 "connection.uri", mongoUri,
                 "connection.host", mongoHost,


### PR DESCRIPTION
The `IsOpen` method previously just checked that a collection was created, however this was on the client and if the database was down, this check would still return "true".

I have updated the `IsOpen` method to check the state of the mongo cluster, and use it's state property to determine connectivity.
_I have left the commented out code in the method, for checking all servers in the cluster, however this may be overkill, and produce false positives in certain situations._

**This change will cause an exception to be thrown when the microservice cannot connect to the mongo persistence, this has the effect of making the service not startup if the mongo persistence cannot be connected to.**

I have created 2 tests for this change.